### PR TITLE
Room cleanup round 2

### DIFF
--- a/nap/data/RoomData.js
+++ b/nap/data/RoomData.js
@@ -232,6 +232,14 @@ var BotRoomData = {
 
 var botname = null;
 
+bonfireDashedNames.map(function (bfName) {
+    var room = {
+        name: "camperbot/" + bfName,
+        isBonfire: true
+    };
+    BotRoomData.camperbot.push(room);
+});
+
 RoomData = {
     rooms: function (botname) {
         botname = botname || AppConfig.getBotName();

--- a/nap/data/RoomData.js
+++ b/nap/data/RoomData.js
@@ -232,23 +232,6 @@ var BotRoomData = {
 
 var botname = null;
 
-bonfireDashedNames.map(function (bfName) {
-    var room = {
-        name: "camperbot/" + bfName,
-        isBonfire: true
-    };
-    BotRoomData.camperbot.push(room);
-});
-
-BotRoomData.camperbot.map(function (room) {
-    room.title = room.title || room.name.split("/")[1];
-    if (room.isBonfire) {
-        //room.entry = "FreeCodeCamp/HelpBonfires",
-        room.entry = "camperbot/testing";
-        room.topic = room.title;
-    }
-});
-
 RoomData = {
     rooms: function (botname) {
         botname = botname || AppConfig.getBotName();


### PR DESCRIPTION
Removed the last of the legacy rooms in RoomData.js

Tested this fuly this time, only joins the following rooms on startup:

```
15 Nov 20:11:55 - [nodemon] 1.7.1
15 Nov 20:11:55 - [nodemon] to restart at any time, enter `rs`
15 Nov 20:11:55 - [nodemon] watching: *.*
15 Nov 20:11:55 - [nodemon] starting `node app.js`
--------------- startup ------------------
WARN> AppConfig AppConfig.init serverEnv: demobot
connect.multipart() will be removed in connect 3.0
visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
connect.limit() will be removed in connect 3.0
GBot> botname on rooms camperbot
Demo app running at http://localhost:7891
GBot> joined>  FreeCodeCamp/admin
GBot> joined>  FreeCodeCamp/camperbot
GBot> joined>  FreeCodeCamp/Casual
GBot> joined>  FreeCodeCamp/CodeReview
GBot> joined>  FreeCodeCamp/CodingJobs
GBot> joined>  FreeCodeCamp/CurriculumDevelopment
GBot> joined>  FreeCodeCamp/DataScience
GBot> joined>  FreeCodeCamp/FreeCodeCamp
GBot> joined>  FreeCodeCamp/Help
GBot> joined>  FreeCodeCamp/HalfWayClub
GBot> joined>  FreeCodeCamp/HelpBasejumps
GBot> joined>  FreeCodeCamp/HelpBonfires
GBot> joined>  FreeCodeCamp/HelpZiplines
GBot> joined>  FreeCodeCamp/LiveCoding
GBot> joined>  FreeCodeCamp/PairProgrammingWomen
GBot> joined>  FreeCodeCamp/YouCanDoThis
```