### PR TITLE
Add npm install to README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ git clone https://github.com/FreeCodeCamp/camperbot.git
 cd camperbot
 cd nap
 cp dot-EXAMPLE.env dot.env
+npm install
 nodemon app.js
 ```
 
@@ -100,6 +101,7 @@ git clone https://github.com/FreeCodeCamp/camperbot.git
 cd gitterbot
 cd nap
 copy dot-EXAMPLE.env dot.env
+npm install
 nodemon app.js
 ```
 


### PR DESCRIPTION
You need to install the necessary Node modules to get the demo bot running.