### PR TITLE
Updated music() to point back to Plug.dj again

### DIFF
--- a/lib/bot/BotCommands.js
+++ b/lib/bot/BotCommands.js
@@ -136,7 +136,7 @@ const BotCommands = {
   // },
 
   music: function() {
-    return '## Music!\n http://musare.com/';
+    return '## Music!\n https://plug.dj/freecodecamp\n Come enjoy some community-selected EDM while you code!';
   },
 
   announce: function(input) {


### PR DESCRIPTION
Since plug.dj is back up and running and Musare is now defunct for the same reason, updated Camperbot's /music command to reflect this.