### PR TITLE
Star at 1000 not 999

### DIFF
--- a/lib/bot/cmds/thanks.js
+++ b/lib/bot/cmds/thanks.js
@@ -106,7 +106,7 @@ const thanksCommands = {
     try {
       const username = blob.response.about.username,
             about = blob.response.about,
-            brownieEmoji = about.browniePoints < 999 ? ':cookie:' : ':star2:',
+            brownieEmoji = about.browniePoints < 1000 ? ':cookie:' : ':star2:',
             uri = 'http://www.freecodecamp.com/' + username;
       str = `> ${brownieEmoji} ${about.browniePoints} | @${username} |`;
       str += TextLib.mdLink(uri, uri);


### PR DESCRIPTION
Give campers the shiny gold star at 1000 brownies instead of 999, seems like a more round number. A few other campers seem to agree it should be 1k. 