### PR TITLE
Fix wiki directory

### DIFF
--- a/lib/bot/KBase.js
+++ b/lib/bot/KBase.js
@@ -28,7 +28,7 @@ const KBase = {
 
   initSync: function() {
     // TODO - FIXME works relative?
-    const wikiDataDir = path.join(__dirname, '/../../data/fcc.wiki');
+    const wikiDataDir = path.join(__dirname, '/../../data/fcc.wiki/deprecated wiki');
 
     KBase.allData = [];
     fs.readdirSync(wikiDataDir).forEach(name => {


### PR DESCRIPTION
With the recent change in the PR https://github.com/FreeCodeCamp/wiki/pull/1257
the wiki was moved to "deprecated wiki" directory.

:warning: Urgent
---- 
@camperbot in chat is broken now.
cc: @BerkeleyTrue @ltegman 