### PR TITLE
Fix code formatting wiki link

### DIFF
--- a/data/rooms/RoomMessages.js
+++ b/data/rooms/RoomMessages.js
@@ -35,7 +35,7 @@ const AllRoomMessages = [
   {
     regex: /'''/,
     text: '> :bulb: to format code use backticks! ``` [more info]' +
-          '(https://github.com/freecodecamp/freecodecamp/wiki/code-formatting)'
+          '(http://forum.freecodecamp.com/t/markdown-code-formatting/18391)'
   },
   {
     regex: /holler/i,


### PR DESCRIPTION
Replaced the previous wiki link that points to Code Formatting, with the new forum link.

 closes freeCodeCamp/freecodecamp#11372
