### PR TITLE
update app.js to support Express 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,25 +13,29 @@ const express = require('express'),
       passport = require('./lib/gitter/passportModule'),
       GBot = require('./lib/bot/GBot'),
       routes = require('./lib/app/routes.js'),
-      path = require('path');
+      path = require('path'),
+      bodyParser = require('body-parser'),
+      cookieParser = require('cookie-parser'),
+      methodOverride = require('method-override'),
+      session = require('express-session'),
+      serveStatic = require('serve-static');     
 
 const app = express();
 
 // Middlewares
 app.set('view engine', 'jade');
 app.set('views', path.join(__dirname, '/views'));
-app.use(express.json());
-app.use(express.urlencoded());
-app.use(express.static(path.join(__dirname, '/public')));
-app.use(express.bodyParser());
-app.use(express.methodOverride());
-app.use(express.cookieParser());
-app.use(express.session({
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded());
+app.use(serveStatic(path.join(__dirname, '/public')));
+app.use(bodyParser());
+app.use(methodOverride());
+app.use(cookieParser());
+app.use(session({
   secret: 'keyboard cat'
 }));
 app.use(passport.initialize());
 app.use(passport.session());
-app.use(app.router);
 
 GBot.init();
 routes.init(app, GBot, passport);

--- a/package.json
+++ b/package.json
@@ -2,15 +2,20 @@
   "name": "camperbot",
   "version": "0.0.13",
   "dependencies": {
+    "body-parser": "~1.16.0",
     "cli-color": "",
+    "cookie-parser": "~1.4.3",
     "dotenv": "^1.2.0",
     "express": "~4.14.0",
+    "express-session": "~1.15.0",
     "jade": "~0.35.0",
     "lodash": "^3.10.1",
+    "method-override": "~2.3.7",
     "node-gitter": "^1.2.8",
     "passport": "~0.2.0",
     "passport-oauth2": "~1.1.1",
-    "request": "~2.27.0"
+    "request": "~2.27.0",
+    "serve-static": "~1.11.2"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
I read the documentation regarding the change from Express 3 to Express 4. There are still some residual deprecations (listed below) but it works now and solves the build error caused by #114 

Residual deprecation messages after changes:
```
body-parser deprecated undefined extended: provide extended option app.js:29:20
body-parser deprecated bodyParser: use individual json/urlencoded middlewares app.js:31:9
body-parser deprecated undefined extended: provide extended option node_modules/body-parser/index.js:105:29
express-session deprecated undefined resave option; provide resave option app.js:34:9
express-session deprecated undefined saveUninitialized option; provide saveUninitialized option app.js:34:9
```