### PR TITLE
Remove rollem command

### DIFF
--- a/lib/bot/BotCommands.js
+++ b/lib/bot/BotCommands.js
@@ -123,12 +123,6 @@ const BotCommands = {
     this.bot.sayToRoom(text, roomName);
   },
 
-  rollem: function(input) {
-    const fromUser = '@' + input.message.model.fromUser.username;
-    return fromUser + ' says enjoy!' +
-      'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
-  },
-
   eightball: function(input) {
     const fromUser = '@' + input.message.model.fromUser.username;
     const replies = [

--- a/test/helpers/testWikiArticle.md
+++ b/test/helpers/testWikiArticle.md
@@ -17,7 +17,6 @@ find js   # all JS entries
 wiki muta  # first entry with muta in name
 wiki bobbytables  # showing images
 wiki video  # and video
-rollem    # secret sauce
 Algorithm roman   # any Algorithm with roman in name
 ```
 For playing with CamperBot please use the testing channel:


### PR DESCRIPTION
Removes the `/rollem` command, as per #118 

Tested with own bot. Results - 

1. Before - :point_up: [February 5, 2017 2:11 AM](https://gitter.im/FreeCodeCamp/camperbotPlayground?at=5896d0205bc3025608cb0e33)

2. After - :point_up: [February 5, 2017 2:19 AM](https://gitter.im/FreeCodeCamp/camperbotPlayground?at=5896d20f3f5ec4d007591626)

Closes #118 