### PR TITLE
allow dots and commas before thanks

### DIFF
--- a/data/rooms/RoomMessages.js
+++ b/data/rooms/RoomMessages.js
@@ -46,7 +46,7 @@ const AllRoomMessages = [
   {
     // tests: https://regex101.com/r/hH5cN7/42
     // eslint-disable-next-line max-len
-    regex: /((?:^|\s)(?:(?:th(?:n[qx]|x)|t[xyq]|tn(?:[x]){0,2})|than[kx](?:[sxz]){0,2}(?:[uq]|y(?:ou)?)?)|grazie|arigato(?:[u]{0,1})|doumo|gracias?|spasibo|dhanyavaad(?:hamulu)?|o?brigad(?:o|a)|dziekuje|(?:re)?merci|multumesc|shukra?an|danke)\b/gi,
+    regex: /((?:^|\s)(?:(?:th(?:n[qx]|x)|t[xyq]|tn(?:[x]){0,2})|\w*\s*[\.,]*\s*than[kx](?:[sxz]){0,2}|than[kx](?:[sxz]){0,2}(?:[uq]|y(?:ou)?)?)|grazie|arigato(?:[u]{0,1})|doumo|gracias?|spasibo|dhanyavaad(?:hamulu)?|o?brigad(?:o|a)|dziekuje|(?:re)?merci|multumesc|shukra?an|danke)\b/gi,
     func: BotCommands.thanks
   },
   {


### PR DESCRIPTION
Amended the regex to allow for dots and commas before `thanks`, as campers tend to often use phrases like - 

> Ah, just realize what I should do....Thanks @xyzzzz

OR
> cool ,thanks @xyzzz

Some phrases tested against the new regex in the `camperbotPlayground` room are - 

1. `blah ,thanks`

1. `blah, thanks`

1. `test again... thanks`

1. `test again, thanks`

1. `foo...thanks`

1. `,thanks`

Test online here - https://regex101.com/r/zdOnh0/1

I did not amend the existing `than[kx](?:[sxz]){0,2}` because placing `\w` and the character class of `[\.,]` before it seemed to affect other thank you words, due to the capture group associated with it.